### PR TITLE
use the multidimensional_urlencode package

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,3 +2,4 @@
 # numpy
 # scipy>=0.9
 httplib2
+multidimensional_urlencode

--- a/shopware_rest/rest.py
+++ b/shopware_rest/rest.py
@@ -6,9 +6,12 @@ import sys
 import logging
 
 try:
-    from urllib.parse import urlencode
+    from multidimensional_urlencode import urlencode
 except ImportError:
-    from urllib import urlencode
+    try:
+        from urllib.parse import urlencode
+    except ImportError:
+        from urllib import urlencode
 
 try:
     from urlparse import urlparse, parse_qsl, urlunparse, urljoin


### PR DESCRIPTION
Hi Fabian,
ich habe für eine Python-Entwicklung deinen Shopware REST Client eingesetzt. Allerdings konnte man keine Filterparameter bei der Abrage nutzen, die mehrdimensional waren. Mit diesem kleinen Commit funktioniert das jetzt auch. Vielen Dank für deine Arbeit!
Nette Grüße,
Oliver.